### PR TITLE
bugfix: right clicking causes drag; added expand/contract graph button

### DIFF
--- a/vis_main.js
+++ b/vis_main.js
@@ -352,7 +352,14 @@ function vis_main(vis_sel) {
             // Update the nodes
             var node = svg_g.selectAll("g.node")
                 .data(nodes, function(d) { return d.id || (d.id = ++i); });
-
+            
+            // Drag behavior not wanted
+            var drag = d3.behavior.drag()
+                .on('dragstart', function () {
+                    d3.event.sourceEvent.stopPropagation();
+                    d3.event.sourceEvent.preventDefault();
+                });
+            
             // Enter any new nodes at the parent's previous position
             var nodeEnter = node.enter().append("svg:g")
                 .attr("class", "node")
@@ -362,7 +369,8 @@ function vis_main(vis_sel) {
                     d3.event.preventDefault();
                     instance.toggleAll(d);
                     instance.update(d);
-                });
+                })
+                .call(drag);
 
             nodeEnter.append("svg:circle")
                 .attr("r", 1e-6)


### PR DESCRIPTION
Yet another pull request (and probably the last?); this time with bug fixes!
- **Bugfix:** Right-clicking a node causes drag behavior to be intialized when it shouldn't (in Chrome)
- **Bugfix:** In the question mark hover, the php code for displaying the X in "A visualization of the X family tree" was broken such that there was no X at all
- **Feature:** Expand/contract graph button next to (?); the expand button will cause the graph to take up the full viewport.
  If the #expanded hash is present in the URL when the page is loaded, the graph will be automatically expanded
- **Change:** made the page look slightly better and more mobile-friendly

Also, I put in the `if (isset($n['children'][0]))` at lines 142 and 151 because when I first downloaded the dump/pedigree.bin and ran graph.php it complained about undefined offsets so it couldn't run
